### PR TITLE
🐛 Fix leading 0 count bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,11 +186,11 @@ pub fn cpu(config: Config) -> Result<(), Box<dyn Error>> {
 
                 // count total and leading zero bytes
                 let mut total = 0;
-                let mut leading = 0;
+                let mut leading = 21;
                 for (i, &b) in address.iter().enumerate() {
                     if b == 0 {
                         total += 1;
-                    } else if leading == 0 {
+                    } else if leading == 21 {
                         // set leading on finding non-zero byte
                         leading = i;
                     }


### PR DESCRIPTION
Currently the leading zero counting logic has a bug that if an address starts with a non-zero byte but has subsequent zero-bytes e.g. `0xaf0000b3...` the logic will essentially skip the leading byte because `0` is used as the "magic value" for recognizing whether the value has been set yet.

I thought of going the Rust way and using options but I assume that has some overhead which wouldn't be good here? Using the unreachable 21 as the magic value fixes this.